### PR TITLE
Fix: cronジョブがJSTで実行されるようにコンテナのタイムゾーンを設定します。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM python:3.11-slim-bookworm
 WORKDIR /app
 
+# Set the timezone to Japan Standard Time.
+ENV TZ=Asia/Tokyo
+
 # Install system dependencies including Chrome and ChromeDriver.
 RUN apt-get update && apt-get install -y \
     cron curl wget gnupg unzip jq && \


### PR DESCRIPTION
cronジョブが、コンテナのタイムゾーンがデフォルトでUTCに設定されていたため、期待された時刻（JSTの6:30と7:00）に実行されていませんでした。

この変更では、`Dockerfile`に`ENV TZ=Asia/Tokyo`を追加することで、タイムゾーンをアジア/東京に設定します。これにより、コンテナ内のcronデーモンが日本標準時で動作し、スケジュールされた時刻にジョブが正しく実行されるようになります。