### PR TITLE
Fix OpenAI API error for unsupported temperature. The model 'gpt-5-mi…

### DIFF
--- a/backend/data_fetcher.py
+++ b/backend/data_fetcher.py
@@ -628,7 +628,6 @@ class MarketDataFetcher:
                 model="gpt-5-mini",
                 messages=messages,
                 max_completion_tokens=max_tokens,
-                temperature=0.7,
                 response_format=response_format
             )
             content = response.choices[0].message.content.strip()


### PR DESCRIPTION
…ni' does not support the 'temperature' parameter, causing an 'invalid_request_error'. This commit removes the parameter from the API call in 'backend/data_fetcher.py' to resolve the issue.