### PR TITLE
Fix: Correct parameter name in logging statement

### DIFF
--- a/backend/data_fetcher.py
+++ b/backend/data_fetcher.py
@@ -620,7 +620,7 @@ class MarketDataFetcher:
         if not self.openai_client:
             raise MarketDataError("E005", "OpenAI client is not available.")
         try:
-            logger.info(f"Calling OpenAI API (max_tokens={max_completion_tokens})...")
+            logger.info(f"Calling OpenAI API (max_completion_tokens={max_completion_tokens})...")
 
             messages = [
                 {


### PR DESCRIPTION
This commit corrects a minor issue in a logging statement within the `_call_openai_api` function. The logged parameter name for the token limit was still `max_tokens` after the functional code was updated to `max_completion_tokens`.

This change updates the log message to correctly reflect the `max_completion_tokens` parameter name, ensuring consistency and clarity in the logs.