### PR TITLE
Fix: Correct parameter name in token limit warning

### DIFF
--- a/backend/data_fetcher.py
+++ b/backend/data_fetcher.py
@@ -648,7 +648,7 @@ class MarketDataFetcher:
                 raise MarketDataError("E005", "Empty response from OpenAI API")
 
             if response.choices[0].finish_reason == 'length':
-                logger.warning("Response may be truncated due to max_tokens limit.")
+                logger.warning("Response may be truncated due to max_completion_tokens limit.")
 
             content = response.choices[0].message.content
 


### PR DESCRIPTION
This commit corrects a minor issue in a warning message within the `_call_openai_api` function. The warning about a truncated response referred to `max_tokens` instead of `max_completion_tokens`.

This change updates the warning message to correctly reflect the `max_completion_tokens` parameter name, ensuring consistency and clarity in the logs.