### PR TITLE
feat: Display AI commentary on heatmaps

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -218,7 +218,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return '#c62828';
     }
 
-    function renderHeatmap(container, title, heatmapData) {
+    function renderHeatmap(container, title, heatmapData, aiCommentary) {
         if (!container) return;
         container.innerHTML = '';
         if (!heatmapData || !heatmapData.stocks || heatmapData.stocks.length === 0) {
@@ -334,6 +334,15 @@ document.addEventListener('DOMContentLoaded', () => {
         
         heatmapWrapper.appendChild(svg.node());
         card.appendChild(heatmapWrapper);
+
+        // --- AI Commentary ---
+        if (aiCommentary) {
+            const commentaryDiv = document.createElement('div');
+            commentaryDiv.className = 'ai-commentary';
+            commentaryDiv.innerHTML = `<h3>AI解説</h3><p>${aiCommentary.replace(/\n/g, '<br>')}</p>`;
+            card.appendChild(commentaryDiv);
+        }
+
         container.appendChild(card);
     }
 
@@ -535,12 +544,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
             renderMarketOverview(document.getElementById('market-content'), data.market);
             renderNews(document.getElementById('news-content'), data.news);
-            renderHeatmap(document.getElementById('nasdaq-heatmap-1d'), 'NASDAQ 100 (1-Day)', data.nasdaq_heatmap_1d);
-            renderHeatmap(document.getElementById('nasdaq-heatmap-1w'), 'NASDAQ 100 (1-Week)', data.nasdaq_heatmap_1w);
-            renderHeatmap(document.getElementById('nasdaq-heatmap-1m'), 'NASDAQ 100 (1-Month)', data.nasdaq_heatmap_1m);
-            renderHeatmap(document.getElementById('sp500-heatmap-1d'), 'S&P 500 (1-Day)', data.sp500_heatmap_1d);
-            renderHeatmap(document.getElementById('sp500-heatmap-1w'), 'S&P 500 (1-Week)', data.sp500_heatmap_1w);
-            renderHeatmap(document.getElementById('sp500-heatmap-1m'), 'S&P 500 (1-Month)', data.sp500_heatmap_1m);
+            renderHeatmap(document.getElementById('nasdaq-heatmap-1d'), 'NASDAQ 100 (1-Day)', data.nasdaq_heatmap_1d, data.nasdaq_heatmap?.ai_commentary);
+            renderHeatmap(document.getElementById('nasdaq-heatmap-1w'), 'NASDAQ 100 (1-Week)', data.nasdaq_heatmap_1w, data.nasdaq_heatmap?.ai_commentary);
+            renderHeatmap(document.getElementById('nasdaq-heatmap-1m'), 'NASDAQ 100 (1-Month)', data.nasdaq_heatmap_1m, data.nasdaq_heatmap?.ai_commentary);
+            renderHeatmap(document.getElementById('sp500-heatmap-1d'), 'S&P 500 (1-Day)', data.sp500_heatmap_1d, data.sp500_heatmap?.ai_commentary);
+            renderHeatmap(document.getElementById('sp500-heatmap-1w'), 'S&P 500 (1-Week)', data.sp500_heatmap_1w, data.sp500_heatmap?.ai_commentary);
+            renderHeatmap(document.getElementById('sp500-heatmap-1m'), 'S&P 500 (1-Month)', data.sp500_heatmap_1m, data.sp500_heatmap?.ai_commentary);
             renderIndicators(document.getElementById('indicators-content'), data.indicators, data.last_updated);
             renderColumn(document.getElementById('column-content'), data.column);
 


### PR DESCRIPTION
Modified the frontend JavaScript to display the AI-generated commentary below the S&P 500 and Nasdaq 100 heatmaps.

- Updated the `renderHeatmap` function in `app.js` to accept an `aiCommentary` string.
- If the commentary is provided, it is rendered in a new div below the heatmap visualization.
- Updated the `fetchDataAndRender` function to pass the relevant AI commentary for each heatmap from the fetched data.