### PR TITLE
feat: Remove limit on news articles for AI analysis

### DIFF
--- a/backend/data_fetcher.py
+++ b/backend/data_fetcher.py
@@ -712,8 +712,8 @@ class MarketDataFetcher:
             }
             return
 
-        # Limit to top 5 news items to avoid overly long prompts
-        top_news = raw_news[:5]
+        # The limit of 5 news items has been removed to allow the AI to analyze all news from the last 24 hours.
+        top_news = raw_news
 
         news_content = ""
         for i, item in enumerate(top_news):


### PR DESCRIPTION
Removes the 5-item limit on news articles sent to the AI for analysis. The AI will now process all news fetched from the last 24 hours to determine the most impactful topics.