### PR TITLE
feat: Reorder heatmap and AI commentary display

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -555,13 +555,13 @@ document.addEventListener('DOMContentLoaded', () => {
             renderHeatmap(document.getElementById('nasdaq-heatmap-1d'), 'NASDAQ 100 (1-Day)', data.nasdaq_heatmap_1d);
             renderHeatmap(document.getElementById('nasdaq-heatmap-1w'), 'NASDAQ 100 (1-Week)', data.nasdaq_heatmap_1w);
             renderHeatmap(document.getElementById('nasdaq-heatmap-1m'), 'NASDAQ 100 (1-Month)', data.nasdaq_heatmap_1m);
-            renderHeatmapCommentary(document.getElementById('nasdaq-content'), data.nasdaq_heatmap?.ai_commentary);
+            renderHeatmapCommentary(document.getElementById('nasdaq-commentary'), data.nasdaq_heatmap?.ai_commentary);
 
             // Render S&P 500 Heatmaps
             renderHeatmap(document.getElementById('sp500-heatmap-1d'), 'S&P 500 (1-Day)', data.sp500_heatmap_1d);
             renderHeatmap(document.getElementById('sp500-heatmap-1w'), 'S&P 500 (1-Week)', data.sp500_heatmap_1w);
             renderHeatmap(document.getElementById('sp500-heatmap-1m'), 'S&P 500 (1-Month)', data.sp500_heatmap_1m);
-            renderHeatmapCommentary(document.getElementById('sp500-content'), data.sp500_heatmap?.ai_commentary);
+            renderHeatmapCommentary(document.getElementById('sp500-commentary'), data.sp500_heatmap?.ai_commentary);
 
             renderIndicators(document.getElementById('indicators-content'), data.indicators, data.last_updated);
             renderColumn(document.getElementById('column-content'), data.column);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,11 +38,13 @@
                 <div id="nasdaq-heatmap-1d"></div>
                 <div id="nasdaq-heatmap-1w"></div>
                 <div id="nasdaq-heatmap-1m"></div>
+                <div id="nasdaq-commentary"></div>
             </div>
             <div id="sp500-content" class="tab-pane">
                 <div id="sp500-heatmap-1d"></div>
                 <div id="sp500-heatmap-1w"></div>
                 <div id="sp500-heatmap-1m"></div>
+                <div id="sp500-commentary"></div>
             </div>
             <div id="indicators-content" class="tab-pane"></div>
             <div id="column-content" class="tab-pane"></div>


### PR DESCRIPTION
Refactors the layout of the S&P 500 and NASDAQ 100 tabs to meet user requirements.

- Modifies `frontend/index.html` to add dedicated containers for the AI commentary (`nasdaq-commentary` and `sp500-commentary`).
- Updates `frontend/app.js` to render the AI commentary into these new dedicated containers.

This change ensures that the components are displayed in the correct vertical order: 1-Day Heatmap, 1-Week Heatmap, 1-Month Heatmap, and finally the AI Commentary.