### PR TITLE
Feat: Adjust heatmap tile size using a logarithmic scale

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -232,7 +232,7 @@ document.addEventListener('DOMContentLoaded', () => {
         heatmapWrapper.innerHTML = `<h2 class="heatmap-main-title">${title}</h2>`;
         const width = 1000, height = 600;
         const svg = d3.create("svg").attr("viewBox", `0 0 ${width} ${height}`).attr("width", "100%").attr("height", "auto").style("font-family", "sans-serif");
-        const root = d3.hierarchy(d3.group(heatmapData.stocks, d => d.sector, d => d.industry)).sum(d => (d && d.market_cap) ? d.market_cap : 0).sort((a, b) => b.value - a.value);
+        const root = d3.hierarchy(d3.group(heatmapData.stocks, d => d.sector, d => d.industry)).sum(d => (d && d.market_cap > 0) ? Math.log(d.market_cap) : 0).sort((a, b) => b.value - a.value);
         d3.treemap().size([width, height]).paddingTop(28).paddingInner(3).round(true)(root);
         const tooltip = d3.select("body").append("div").attr("class", "heatmap-tooltip").style("opacity", 0);
         const node = svg.selectAll("g").data(root.descendants()).join("g").attr("transform", d => `translate(${d.x0},${d.y0})`);


### PR DESCRIPTION
The original heatmap implementation sized tiles directly based on stock market capitalization. This caused a significant problem where stocks with smaller market caps were rendered too small to be visible or legible, diminishing the heatmap's utility.

To address this, the tile size calculation in the D3.js treemap has been updated. Instead of using the raw market capitalization value, the calculation now uses the natural logarithm (`Math.log()`) of the market cap.

This change dramatically reduces the extreme differences in tile sizes between large-cap and small-cap stocks, resulting in a more balanced and readable visualization where all tiles are clearly visible.