### PR TITLE
refactor: Remove unused Chrome and ChromeDriver from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,26 +5,13 @@ WORKDIR /app
 # Set the timezone to Japan Standard Time.
 ENV TZ=Asia/Tokyo
 
-# Install system dependencies including Chrome and ChromeDriver.
+# Install system dependencies.
 RUN apt-get update && apt-get install -y \
-    cron curl wget gnupg unzip jq && \
-    # Add Chrome repository
-    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
-    apt-get update && \
-    # Install Chrome
-    apt-get install -y google-chrome-stable && \
-    # Install ChromeDriver using the new JSON endpoints
-    CHROMEDRIVER_URL=$(curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -r '.channels.Stable.downloads.chromedriver[] | select(.platform=="linux64").url') && \
-    wget -q -O /tmp/chromedriver.zip ${CHROMEDRIVER_URL} && \
-    unzip /tmp/chromedriver.zip -d /tmp/ && \
-    mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver && \
-    chmod +x /usr/local/bin/chromedriver && \
-    rm /tmp/chromedriver.zip && \
-    rm -rf /tmp/chromedriver-linux64 && \
+    cron \
+    curl \
     # Cleanup
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy backend requirements and install Python packages.
 COPY backend/requirements.txt .


### PR DESCRIPTION
Chrome and ChromeDriver were previously installed in the Docker image but are no longer used by the application. The data fetching process was updated to use `curl-cffi` instead of a full browser automation tool like Selenium.

This change removes the installation of:
- google-chrome-stable
- chromedriver
- Unnecessary dependencies: wget, gnupg, unzip, jq

This reduces the Docker image size and removes unnecessary components.