### PR TITLE
feat(frontend): ヒートマップのレイアウトとデータフィルタリングを更新

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -226,18 +226,16 @@ document.addEventListener('DOMContentLoaded', () => {
         const isSP500 = title.includes('SP500');
         let etfStartIndex = -1;
 
-        // Special handling for SP500: filter top 30 stocks and combine with ETFs
         if (isSP500 && items.length > 0) {
             const stocks = items.filter(d => d.market_cap);
             const etfs = items.filter(d => !d.market_cap);
-
             stocks.sort((a, b) => b.market_cap - a.market_cap);
             const top30Stocks = stocks.slice(0, 30);
-
             items = [...top30Stocks, ...etfs];
-            etfStartIndex = top30Stocks.length; // The index where ETFs start
-        } else if (heatmapData?.stocks) { // For Nasdaq
+            etfStartIndex = top30Stocks.length;
+        } else if (!isSP500 && items.length > 0) { // For Nasdaq
             items.sort((a, b) => b.market_cap - a.market_cap);
+            items = items.slice(0, 30); // Get top 30
         }
 
         if (items.length === 0) {
@@ -251,7 +249,7 @@ document.addEventListener('DOMContentLoaded', () => {
         heatmapWrapper.innerHTML = `<h2 class="heatmap-main-title">${title}</h2>`;
 
         const numItems = items.length;
-        const itemsPerRow = isSP500 ? 7 : 6;
+        const itemsPerRow = 6; // Set to 6 for both
 
         const margin = { top: 10, right: 10, bottom: 10, left: 10 };
         const containerWidth = container.clientWidth || 1000;
@@ -259,22 +257,31 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const tilePadding = 5;
         const tileWidth = (width - (itemsPerRow - 1) * tilePadding) / itemsPerRow;
-        const tileHeight = tileWidth * 2; // Aspect ratio 2:1
-        const etfGap = isSP500 ? tileHeight / 2 : 0; // Gap for SP500 chart
+        const tileHeight = tileWidth; // Make it square
+        const etfGap = isSP500 ? tileHeight * 0.5 : 0; // Gap for SP500 chart
 
         // Calculate total height dynamically
         let totalHeight = 0;
-        const rowHeights = [];
+        let yPos = 0;
+        const yPositions = []; // Store y position for each item
+
         for (let i = 0; i < numItems; i++) {
-            const row = Math.floor(i / itemsPerRow);
-            if (!rowHeights[row]) {
-                rowHeights[row] = tileHeight;
-                if (isSP500 && etfStartIndex !== -1 && i === etfStartIndex && (i % itemsPerRow === 0)) {
-                   totalHeight += etfGap;
+            // Force a new row for the first ETF
+            if (isSP500 && i === etfStartIndex) {
+                // If the first ETF is not at the start of a row, move to next row
+                if (i % itemsPerRow !== 0) {
+                    yPos += tileHeight + tilePadding;
                 }
-                totalHeight += (row > 0 ? tilePadding : 0) + tileHeight;
+                yPos += etfGap; // Add the gap before the ETF row
+            }
+            yPositions.push(yPos);
+            // Move to next row
+            if ((i + 1) % itemsPerRow === 0 && i + 1 < numItems) {
+                yPos += tileHeight + tilePadding;
             }
         }
+        totalHeight = yPos + tileHeight; // Add height of the last row
+
 
         const svg = d3.create("svg")
             .attr("viewBox", `0 0 ${containerWidth} ${totalHeight + margin.top + margin.bottom}`)
@@ -294,27 +301,10 @@ document.addEventListener('DOMContentLoaded', () => {
             .enter()
             .append("g")
             .attr("transform", (d, i) => {
-                const row = Math.floor(i / itemsPerRow);
                 const col = i % itemsPerRow;
-
-                let yOffset = 0;
-                for(let j = 0; j < row; j++) {
-                    yOffset += rowHeights[j] + tilePadding;
-                }
-
-                if (isSP500 && etfStartIndex !== -1 && i >= etfStartIndex) {
-                    // Check if this is the first row of ETFs
-                    if (Math.floor(etfStartIndex / itemsPerRow) === row) {
-                         if(col === 0){ // Add gap only once per row
-                             yOffset += etfGap;
-                         }
-                    } else if (Math.floor(etfStartIndex / itemsPerRow) < row) {
-                         yOffset += etfGap;
-                    }
-                }
-
                 const x = col * (tileWidth + tilePadding);
-                return `translate(${x},${yOffset})`;
+                const y = yPositions[i];
+                return `translate(${x},${y})`;
             });
 
         nodes.append("rect")
@@ -339,16 +329,20 @@ document.addEventListener('DOMContentLoaded', () => {
             .attr("dominant-baseline", "central")
             .style("pointer-events", "none");
 
+        // Dynamically adjust font size based on tile width
+        const tickerFontSize = Math.max(10, Math.min(tileWidth / 3, 24));
+        const perfFontSize = Math.max(8, Math.min(tileWidth / 4, 18));
+
         text.append("tspan")
             .attr("class", "ticker-label")
-            .style("font-size", "32px") // Double font size
+            .style("font-size", `${tickerFontSize}px`)
             .text(d => d.ticker);
 
         text.append("tspan")
             .attr("class", "performance-label")
             .attr("x", tileWidth / 2)
             .attr("dy", "1.2em")
-            .style("font-size", "24px") // Double font size
+            .style("font-size", `${perfFontSize}px`)
             .text(d => `${d.performance.toFixed(2)}%`);
 
         heatmapWrapper.appendChild(svg.node());


### PR DESCRIPTION
Nasdaq 100およびS&P 500ヒートマップタブに関するユーザーのフィードバックに対応します。

`frontend/app.js`に以下の変更を行いました：
- **正方形タイル:** より統一感のある見た目のため、ヒートマップタイルを正方形にしました。
- **6列グリッド:** NasdaqおよびS&P 500ヒートマップは、1行に6つのタイルを表示するようになりました。
- **Nasdaq 上位30:** Nasdaqヒートマップは、時価総額上位30銘柄のみを表示するようにフィルタリングされるようになりました。
- **S&P 500 ETFの分離:** S&P 500ヒートマップのETFセクションは、常に株式とは別の新しい行に、明確な視覚的ギャップを設けて表示されるようになりました。すべてのコンテンツが表示され、途切れないようにSVGの高さは動的に計算されます。
- **動的フォントサイズ:** 小さなタイルでの読みやすさを向上させるため、タイルラベルに動的なフォントサイズ調整を追加しました。