### PR TITLE
feat: Update heatmap text color and size

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -330,8 +330,8 @@ document.addEventListener('DOMContentLoaded', () => {
             .style("pointer-events", "none");
 
         // Dynamically adjust font size based on tile width
-        const tickerFontSize = Math.max(10, Math.min(tileWidth / 3, 24));
-        const perfFontSize = Math.max(8, Math.min(tileWidth / 4, 18));
+        const tickerFontSize = Math.max(10, Math.min(tileWidth / 3, 24)) * 2;
+        const perfFontSize = Math.max(8, Math.min(tileWidth / 4, 18)) * 2;
 
         text.append("tspan")
             .attr("class", "ticker-label")

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -237,10 +237,10 @@ body {
 }
 
 .stock-label {
-    fill: white;
+    fill: black;
     font-weight: bold;
     pointer-events: none;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.7);
+    text-shadow: none;
     /* font-size is now set dynamically in JavaScript */
 }
 


### PR DESCRIPTION
Changed the text color on heatmap tiles to black for better readability. Doubled the font size of the ticker and performance percentage as requested.