### PR TITLE
feat: Redesign the news tab

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -159,52 +159,85 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function renderNews(container, newsData) {
+    function renderNews(container, newsData, lastUpdated) {
         if (!container) return;
         container.innerHTML = '';
         if (!newsData || (!newsData.summary && (!newsData.topics || newsData.topics.length === 0))) {
             container.innerHTML = '<div class="card"><p>ニュースデータがありません。</p></div>';
             return;
         }
+
         const card = document.createElement('div');
-        card.className = 'card';
+        card.className = 'card news-card'; // Add news-card for specific styling
+
+        // --- Summary Section ---
         if (newsData.summary) {
-            card.innerHTML += `<div class="news-summary"><h3>今朝の3行サマリー</h3><p>${newsData.summary.replace(/\n/g, '<br>')}</p></div>`;
+            const summaryContainer = document.createElement('div');
+            summaryContainer.className = 'news-summary';
+
+            // Title and Date
+            const summaryHeader = document.createElement('div');
+            summaryHeader.className = 'news-summary-header';
+            summaryHeader.innerHTML = '<h3>今朝の3行サマリー</h3>';
+            if (lastUpdated) {
+                const date = new Date(lastUpdated);
+                const dateString = `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日 ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`;
+                summaryHeader.innerHTML += `<p class="summary-date">${dateString}</p>`;
+            }
+
+            // Body and Image
+            const summaryBody = document.createElement('div');
+            summaryBody.className = 'news-summary-body';
+            summaryBody.innerHTML = `<p>${newsData.summary.replace(/\n/g, '<br>')}</p>`;
+            summaryBody.innerHTML += `<img src="icons/suit.PNG" alt="suit" class="summary-image">`;
+
+            summaryContainer.appendChild(summaryHeader);
+            summaryContainer.appendChild(summaryBody);
+            card.appendChild(summaryContainer);
         }
+
+        // --- Topics Section ---
         if (newsData.topics && newsData.topics.length > 0) {
+            const topicsOuterContainer = document.createElement('div');
+            topicsOuterContainer.className = 'main-topics-outer-container';
+            topicsOuterContainer.innerHTML = '<h3>主要トピック</h3>';
+
             const topicsContainer = document.createElement('div');
             topicsContainer.className = 'main-topics-container';
-            topicsContainer.innerHTML = '<h3>主要トピック</h3>';
+
             newsData.topics.forEach((topic, index) => {
+                const topicBox = document.createElement('div');
+                topicBox.className = 'topic-box';
+
                 let topicContent = '';
                 if (topic.analysis && topic.url) {
-                    // 新しいフォーマット（analysis, url）
-                    topicContent = `
-                        <div class="topic-analysis">
-                            <p>${topic.analysis.replace(/\n/g, '<br>')}</p>
-                            <a href="${topic.url}" target="_blank" rel="noopener noreferrer" class="topic-source-link">情報源</a>
-                        </div>
-                    `;
-                } else if (topic.fact || topic.interpretation || topic.impact) {
-                    // 古いフォーマット（fact, interpretation, impact）との互換性
+                    topicContent = `<p>${topic.analysis.replace(/\n/g, '<br>')}</p>`;
+                } else if (topic.body) {
+                    topicContent = `<p>${topic.body}</p>`;
+                } else {
                     topicContent = `
                         <p><strong>事実:</strong> ${topic.fact || 'N/A'}</p>
                         <p><strong>解釈:</strong> ${topic.interpretation || 'N/A'}</p>
                         <p><strong>市場への影響:</strong> ${topic.impact || 'N/A'}</p>
                     `;
-                } else if (topic.body) {
-                    // 古いフォーマット（body）との互換性
-                    topicContent = `<p>${topic.body}</p>`;
                 }
 
-                topicsContainer.innerHTML += `
-                    <div class="topic-box">
-                        <p class="topic-title ${index === 0 ? 'topic-title-red' : 'topic-title-blue'}">${index + 1}. ${topic.title}</p>
-                        ${topicContent}
-                    </div>`;
+
+                topicBox.innerHTML = `
+                    <div class="topic-number-container">
+                        <div class="topic-number">${index + 1}</div>
+                    </div>
+                    <div class="topic-details">
+                        <p class="topic-title">${topic.title}</p>
+                        <div class="topic-content">${topicContent}</div>
+                    </div>
+                `;
+                topicsContainer.appendChild(topicBox);
             });
-            card.appendChild(topicsContainer);
+            topicsOuterContainer.appendChild(topicsContainer);
+            card.appendChild(topicsOuterContainer);
         }
+
         container.appendChild(card);
     }
 
@@ -562,7 +595,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             renderMarketOverview(document.getElementById('market-content'), data.market);
-            renderNews(document.getElementById('news-content'), data.news);
+            renderNews(document.getElementById('news-content'), data.news, data.last_updated);
 
             // Render NASDAQ Heatmaps
             renderGridHeatmap(document.getElementById('nasdaq-heatmap-1d'), 'Nasdaq (1-Day)', data.nasdaq_heatmap_1d);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -266,42 +266,125 @@ body {
 }
 
 /* --- News Styles --- */
-.news-summary {
-    margin-bottom: 20px;
+.news-card {
+    padding: 0;
+    background-color: transparent;
+    box-shadow: none;
 }
 
-.news-summary h3, .main-topics-container h3 {
-    margin-top: 0;
-    color: var(--tab-text);
-    font-size: 1.2em;
-    border-bottom: 2px solid var(--border-color);
-    padding-bottom: 5px;
+.news-summary {
+    background-color: var(--card-background);
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 30px;
+    box-shadow: 0 4px 12px var(--shadow-color);
+}
+
+.news-summary-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 10px;
+    margin-bottom: 15px;
+}
+
+.news-summary-header h3 {
+    margin: 0;
+    font-size: 1.3em;
+    color: var(--text-primary);
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.summary-date {
+    margin: 0;
+    font-size: 0.9em;
+    color: var(--text-secondary);
+}
+
+.news-summary-body {
+    position: relative;
+    padding-bottom: 80px; /* Space for the image */
+}
+
+.news-summary-body p {
+    margin: 0;
+    line-height: 1.8;
+}
+
+.summary-image {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: 100px;
+    width: auto;
+}
+
+.main-topics-outer-container h3 {
+    font-size: 1.3em;
+    color: var(--text-primary);
+    margin-bottom: 15px;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 10px;
 }
 
 .main-topics-container {
-    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
 }
 
 .topic-box {
-    background-color: var(--background);
-    border: 1px solid var(--border-color);
+    display: flex;
+    align-items: flex-start;
+    gap: 15px;
+    background-color: #EAF4FF; /* Light blue background */
+    padding: 20px;
+    border-radius: 10px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
+    border: none;
+}
+
+.topic-number-container {
+    flex-shrink: 0;
+}
+
+.topic-number {
+    width: 36px;
+    height: 36px;
     border-radius: 8px;
-    padding: 15px;
-    margin-bottom: 15px;
+    background: linear-gradient(135deg, #FFD700, #FFA500); /* Gold to Orange gradient */
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2em;
+    font-weight: bold;
+}
+
+.topic-details {
+    flex-grow: 1;
 }
 
 .topic-title {
     font-weight: bold;
+    font-size: 1.1em;
     margin: 0 0 8px 0;
-    font-size: 1em;
+    color: var(--text-primary);
 }
 
-.topic-title-red { color: #c62828; }
-.topic-title-blue { color: #1565c0; }
-
-.topic-box p {
+.topic-content p {
     margin: 0;
     font-size: 0.95em;
+    line-height: 1.7;
+    color: #333;
+}
+
+/* Override old news styles */
+.news-summary h3, .main-topics-container h3 {
+    border-bottom: none;
+    padding-bottom: 0;
 }
 
 /* --- Market Tab Styles --- */


### PR DESCRIPTION
This commit redesigns the news tab to match the new design provided by the user.

- Updates the HTML structure in `frontend/app.js` to support the new layout for the "Today's 3-line summary" and "Main Topics" sections.
- Adds the image of a woman in a suit to the summary section.
- Adds new CSS styles in `frontend/style.css` to implement the new design, including gradient-background numbers for topics and improved layout.