### PR TITLE
feat: Adjust heatmap font size multiplier

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -363,8 +363,8 @@ document.addEventListener('DOMContentLoaded', () => {
             .style("pointer-events", "none");
 
         // Dynamically adjust font size based on tile width
-        const tickerFontSize = Math.max(10, Math.min(tileWidth / 3, 24)) * 2;
-        const perfFontSize = Math.max(8, Math.min(tileWidth / 4, 18)) * 2;
+        const tickerFontSize = Math.max(10, Math.min(tileWidth / 3, 24)) * 1.5;
+        const perfFontSize = Math.max(8, Math.min(tileWidth / 4, 18)) * 1.5;
 
         text.append("tspan")
             .attr("class", "ticker-label")


### PR DESCRIPTION
Changed the font size multiplier for the Nasdaq 100 and S&P 500 heatmap tiles from 2x to 1.5x as requested.

This change was made in `frontend/app.js` in the `renderGridHeatmap` function.