### PR TITLE
Fix: テキストが画像の背後に回り込む問題を修正

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -304,8 +304,7 @@ body {
 }
 
 .news-summary-body {
-    position: relative;
-    padding-bottom: 80px; /* Space for the image */
+    overflow: auto; /* Clear the float */
 }
 
 .news-summary-body p {
@@ -314,9 +313,8 @@ body {
 }
 
 .summary-image {
-    position: absolute;
-    bottom: 0;
-    right: 0;
+    float: right;
+    margin: 0 0 10px 10px;
     height: 100px;
     width: auto;
 }


### PR DESCRIPTION
ニュースタブの「今朝の3行サマリー」セクションで、テキストが画像の背後に回り込んでしまい、隠れてしまう問題を修正しました。

- `.summary-image` に `float: right` を適用し、画像を右側に配置
- `.news-summary-body` に `overflow: auto` を追加し、`float`をクリア
- `position: absolute` を削除し、レイアウトを `float` ベースに変更
- 画像の周囲に `margin` を追加して、テキストとの間隔を確保