### PR TITLE
feat: Increase font size of Fear & Greed historical data

### DIFF
--- a/backend/image_generator.py
+++ b/backend/image_generator.py
@@ -123,12 +123,12 @@ def generate_fear_greed_chart(data):
 
         current_y = start_y + i * y_step
 
-        ax.text(x_label, current_y, label, ha='left', va='center', fontsize=10, color='grey')
-        ax.text(x_status, current_y, status, ha='left', va='center', fontsize=10, fontweight='bold')
+        ax.text(x_label, current_y, label, ha='left', va='center', fontsize=11, color='grey')
+        ax.text(x_status, current_y, status, ha='left', va='center', fontsize=11, fontweight='bold')
 
         circle = Circle((x_circle, current_y), 0.1, facecolor=bg, edgecolor=border, linewidth=1.0, zorder=3)
         ax.add_patch(circle)
-        ax.text(x_circle, current_y, str(val), ha='center', va='center', fontsize=10, fontweight='bold', color='black')
+        ax.text(x_circle, current_y, str(val), ha='center', va='center', fontsize=11, fontweight='bold', color='black')
 
         if i < len(history_keys) - 1:
             line_y = current_y + y_step / 2


### PR DESCRIPTION
Increases the font size of the labels, status text, and values in the historical data section of the Fear & Greed Index image.

The font size is changed from 10 to 11 to match the size of the main category labels (e.g., 'EXTREME FEAR'), improving readability and consistency as requested by the user.