### PR TITLE
feat: Adjust heatmap color contrast

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -252,13 +252,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function getPerformanceColor(performance) {
-        if (performance >= 3) return '#00c853';
-        if (performance > 1) return '#2e7d32';
-        if (performance > 0) return '#66bb6a';
-        if (performance == 0) return '#888888';
-        if (performance > -1) return '#ef5350';
-        if (performance > -3) return '#e53935';
-        return '#c62828';
+        // From bright to dark for positive performance
+        if (performance >= 3) return '#00c853'; // bright green
+        if (performance > 1) return '#66bb6a'; // light green
+        if (performance > 0) return '#2e7d32'; // dark green
+
+        if (performance == 0) return '#888888'; // grey
+
+        // From dark to bright for negative performance
+        if (performance > -1) return '#e53935'; // dark red
+        if (performance > -3) return '#ef5350'; // light red
+        return '#c62828'; // bright red
     }
 
     function renderGridHeatmap(container, title, heatmapData) {


### PR DESCRIPTION
ヒートマップのパフォーマンス表示の色のコントラストを調整します。

- 上昇率・下落率が大きいほど色が明るく、小さいほど暗くなるように変更しました。
- ユーザーの要求に基づき、色の順序を以下のように変更しました。
    - 上昇（プラス）: 明るい緑 -> 少し明るい緑 -> 暗い緑
    - 下落（マイナス）: 暗い赤 -> 少し明るい赤 -> 明るい赤