### PR TITLE
fix(frontend): Correctly display daily and weekly AI columns

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -560,7 +560,14 @@ document.addEventListener('DOMContentLoaded', () => {
     function renderColumn(container, columnData) {
         if (!container) return;
         container.innerHTML = '';
-        const report = columnData ? columnData.weekly_report : null;
+
+        // Case 0: columnData itself is an error string.
+        if (typeof columnData === 'string') {
+            container.innerHTML = `<div class="card"><p>${columnData}</p></div>`;
+            return;
+        }
+
+        const report = columnData ? (columnData.daily_report || columnData.weekly_report) : null;
 
         // Case 1: Success - content is available
         if (report && report.content) {
@@ -568,7 +575,7 @@ document.addEventListener('DOMContentLoaded', () => {
             card.className = 'card';
             card.innerHTML = `
                 <div class="column-container">
-                    <h3>${report.title || '週次AIコラム'}</h3>
+                    <h3>${report.title || 'AIコラム'}</h3>
                     <p class="column-date">Date: ${report.date || ''}</p>
                     <div class="column-content">
                         ${report.content.replace(/\n/g, '<br>')}
@@ -576,7 +583,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 </div>
             `;
             container.appendChild(card);
-        // Case 2: Failure - an error is reported
+        // Case 2: Failure - an error is reported inside the report object
         } else if (report && report.error) {
             container.innerHTML = '<div class="card"><p>生成が失敗しました。</p></div>';
         // Case 3: Not yet generated


### PR DESCRIPTION
Refactors the `renderColumn` function to handle multiple data structures and error states for the AI column.

- The function now checks for `daily_report` or `weekly_report` in the data object, fixing a bug where daily columns were ignored.
- It handles cases where the `column` data is an error string from the backend.
- The default title is now a generic "AIコラム" to suit both daily and weekly reports.

This makes the column display logic more robust and aligns it with the backend's data generation schedule.