### PR TITLE
Fix(docker): Ensure cron jobs run correctly in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,16 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY backend /app/backend
 COPY frontend /app/frontend
 
-# Make cron scripts executable
-RUN chmod +x /app/backend/cron_job_*.sh
+# Copy the startup script
+COPY start.sh /app/start.sh
+
+# Make scripts executable
+RUN chmod +x /app/start.sh
+RUN chmod +x /app/backend/run_job.sh
 
 # Add cron job
 COPY backend/cron_jobs /etc/cron.d/hanaview-cron
 RUN chmod 0644 /etc/cron.d/hanaview-cron
 
-# Start services.
-CMD cron && cd /app/backend && uvicorn main:app --host 0.0.0.0 --port 8000
+# Start services using the startup script
+CMD [ "/app/start.sh" ]

--- a/backend/cron_job_fetch.sh
+++ b/backend/cron_job_fetch.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-LOG_DIR="/app/logs"
-echo "$(date): Starting data fetch..." >> $LOG_DIR/cron.log
-cd /app
-python -m backend.data_fetcher fetch >> $LOG_DIR/fetch.log 2>&1
-echo "$(date): Data fetch completed" >> $LOG_DIR/cron.log

--- a/backend/cron_job_generate.sh
+++ b/backend/cron_job_generate.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-LOG_DIR="/app/logs"
-echo "$(date): Starting report generation..." >> $LOG_DIR/cron.log
-cd /app
-python -m backend.data_fetcher generate >> $LOG_DIR/generate.log 2>&1
-echo "$(date): Report generation completed" >> $LOG_DIR/cron.log

--- a/backend/cron_jobs
+++ b/backend/cron_jobs
@@ -1,4 +1,7 @@
 # Data fetch (Mon-Fri 6:30 JST)
-30 6 * * 1-5 root /app/backend/cron_job_fetch.sh
+# The `backend/cron-env.sh` file is created by the start.sh script and contains the environment variables.
+# The `run_job.sh` script handles the execution and logging.
+30 6 * * 1-5 root . /app/backend/cron-env.sh; /app/backend/run_job.sh fetch >> /app/logs/cron_error.log 2>&1
+
 # Report generation (Mon-Fri 7:00 JST)
-0 7 * * 1-5 root /app/backend/cron_job_generate.sh
+0 7 * * 1-5 root . /app/backend/cron-env.sh; /app/backend/run_job.sh generate >> /app/logs/cron_error.log 2>&1

--- a/backend/run_job.sh
+++ b/backend/run_job.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This script is executed by cron to run a fetch or generate job.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Define the project's root directory.
+APP_DIR="/app"
+LOG_DIR="${APP_DIR}/logs"
+JOB_TYPE=$1
+
+# Ensure log directory exists
+mkdir -p "$LOG_DIR"
+
+# Log the job start
+echo "$(date): Starting job: ${JOB_TYPE}" >> "${LOG_DIR}/cron.log"
+
+# Execute the python script, redirecting stdout and stderr to a job-specific log file
+# The python executable is called from the system path, as configured in the Dockerfile.
+python3 -m backend.data_fetcher ${JOB_TYPE} >> "${LOG_DIR}/${JOB_TYPE}.log" 2>&1
+
+# Log the job completion
+echo "$(date): Completed job: ${JOB_TYPE}" >> "${LOG_DIR}/cron.log"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This script is the entrypoint for the Docker container.
+# It starts the cron daemon and the uvicorn server.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Define the location for the cron environment file
+ENV_FILE="/app/backend/cron-env.sh"
+
+echo "Creating cron environment file at ${ENV_FILE}"
+# Create a shell script that exports all current environment variables.
+# This makes environment variables from docker-compose.yml (via .env) available to cron jobs.
+printenv | sed 's/^\(.*\)$/export \1/g' > "${ENV_FILE}"
+chmod +x "${ENV_FILE}"
+
+echo "Starting cron daemon..."
+# Start cron in the background
+cron
+
+echo "Starting Uvicorn web server..."
+# Start the uvicorn server in the foreground.
+# This will be the main process that keeps the container running.
+exec uvicorn main:app --host 0.0.0.0 --port 8000 --app-dir /app/backend


### PR DESCRIPTION
The previous setup failed to run cron jobs because the cron daemon did not inherit the necessary environment variables (like OPENAI_API_KEY) from the container's environment, and the container's CMD did not correctly manage both the cron and uvicorn processes.

This commit completely refactors the container startup and cron execution logic to solve the issue:

1.  **Introduces `start.sh` as the container entrypoint.** This script performs two key actions:
    - It captures all available environment variables and writes them to `/app/backend/cron-env.sh`.
    - It starts the `cron` daemon in the background and then `exec`s `uvicorn`, making it the main container process.

2.  **Adds a unified `run_job.sh` script.** This replaces the two older `cron_job_*.sh` scripts, providing a single, more robust script for executing the `fetch` and `generate` tasks.

3.  **Updates `cron_jobs`:** The crontab entries are modified to first source the new `cron-env.sh` file, ensuring the jobs run with the correct environment, before calling `run_job.sh`.

4.  **Updates `Dockerfile`:** The Dockerfile is modified to copy the new scripts and use `start.sh` as its `CMD`.

5.  **Removes obsolete scripts:** The old `cron_job_fetch.sh` and `cron_job_generate.sh` files are deleted.

This new setup follows best practices for running cron alongside a web service in a Docker container, ensuring reliable, automated execution of the scheduled tasks.