### PR TITLE
feat(frontend): AI解説の更新日時レイアウトを修正

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -27,6 +27,27 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    // --- Date Formatting Helper ---
+    function formatDateForDisplay(dateInput) {
+        if (!dateInput) return '';
+        try {
+            const date = new Date(dateInput);
+            if (isNaN(date.getTime())) {
+                console.error("Invalid date input for formatting:", dateInput);
+                return '';
+            }
+            const year = date.getFullYear();
+            const month = date.getMonth() + 1;
+            const day = date.getDate();
+            const hours = String(date.getHours()).padStart(2, '0');
+            const minutes = String(date.getMinutes()).padStart(2, '0');
+            return `${year}年${month}月${day}日 ${hours}:${minutes}`;
+        } catch (e) {
+            console.error("Error formatting date:", dateInput, e);
+            return '';
+        }
+    }
+
     // --- Rendering Functions ---
 
     function renderLightweightChart(containerId, data, title) {
@@ -139,12 +160,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // AI Commentary
         if (marketData.ai_commentary) {
-            const dateString = lastUpdated ? `<p class="commentary-date">更新日時: ${new Date(lastUpdated).toLocaleString('ja-JP')}</p>` : '';
+            const formattedDate = formatDateForDisplay(lastUpdated);
+            const dateHtml = formattedDate ? `<p class="ai-date">${formattedDate}</p>` : '';
             content += `
                 <div class="market-section">
-                    <h3>AI解説</h3>
-                    <p>${marketData.ai_commentary}</p>
-                    ${dateString}
+                    <div class="ai-header">
+                        <h3>AI解説</h3>
+                        ${dateHtml}
+                    </div>
+                    <p>${marketData.ai_commentary.replace(/\n/g, '<br>')}</p>
                 </div>
             `;
         }
@@ -581,10 +605,14 @@ document.addEventListener('DOMContentLoaded', () => {
         if (report && report.content) {
             const card = document.createElement('div');
             card.className = 'card';
+            const formattedDate = formatDateForDisplay(report.date);
+            const dateHtml = formattedDate ? `<p class="ai-date">${formattedDate}</p>` : '';
             card.innerHTML = `
                 <div class="column-container">
-                    <h3>${report.title || 'AI解説'}</h3>
-                    <p class="column-date">Date: ${report.date || ''}</p>
+                    <div class="ai-header">
+                        <h3>${report.title || 'AI解説'}</h3>
+                        ${dateHtml}
+                    </div>
                     <div class="column-content">
                         ${report.content.replace(/\n/g, '<br>')}
                     </div>
@@ -607,11 +635,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const card = document.createElement('div');
         card.className = 'card';
 
-        const dateString = lastUpdated ? `<p class="commentary-date">更新日時: ${new Date(lastUpdated).toLocaleString('ja-JP')}</p>` : '';
+        const formattedDate = formatDateForDisplay(lastUpdated);
+        const dateHtml = formattedDate ? `<p class="ai-date">${formattedDate}</p>` : '';
 
         const commentaryDiv = document.createElement('div');
         commentaryDiv.className = 'ai-commentary';
-        commentaryDiv.innerHTML = `<h3>AI解説</h3><p>${commentary.replace(/\n/g, '<br>')}</p>${dateString}`;
+        commentaryDiv.innerHTML = `
+            <div class="ai-header">
+                <h3>AI解説</h3>
+                ${dateHtml}
+            </div>
+            <p>${commentary.replace(/\n/g, '<br>')}</p>
+        `;
 
         card.appendChild(commentaryDiv);
         container.appendChild(card);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -454,12 +454,6 @@ body {
     margin-bottom: 15px;
 }
 
-.commentary-date {
-    font-size: 0.9em;
-    color: var(--text-secondary);
-    margin-top: 15px;
-    text-align: right;
-}
 .market-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
@@ -545,19 +539,34 @@ body {
     margin: 4px 0;
 }
 
-/* --- Column Tab Styles --- */
-.column-container h3 {
-    color: var(--tab-text);
-    font-size: 1.3em;
+/* --- AI Commentary & Column Styles --- */
+.ai-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     border-bottom: 2px solid var(--border-color);
     padding-bottom: 8px;
-    margin-bottom: 5px;
-}
-.column-date {
-    font-size: 0.9em;
-    color: var(--text-secondary);
     margin-bottom: 15px;
 }
+
+.ai-header h3 {
+    color: var(--tab-text);
+    font-size: 1.3em;
+    margin: 0;
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.ai-date {
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    margin: 0;
+    white-space: nowrap;
+    padding-left: 15px;
+}
+
+/* --- Column Tab Styles --- */
+/* Styles for .column-container h3 and .column-date are now handled by .ai-header */
 .column-content {
     line-height: 1.7;
 }


### PR DESCRIPTION
市況、ヒートマップ、コラムの各タブに含まれるAI解説セクションのレイアウトを変更。

- 更新日時を「AI解説」タイトルの右横に配置
- 日時フォーマットを「YYYY年M月D日 HH:mm」形式に統一
- 「更新日時:」というプレフィックスを削除

汎用的なCSSクラス`.ai-header`と日付フォーマット用のJavaScript関数を導入し、複数のタブで一貫した表示を実現。