### PR TITLE
コラムタブで参考にしているhana-memo-202509.txtの記述を.envで管理するように修正しました。

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 SPECIAL_TICKERS='{"2025/04/16": ["ASML", "(エーエスエムエル・ホールディングス)"], "2025/05/07": ["ARM", "(アーム・ホールディングス)"], "2025/03/12": ["PDD", "(ピンドゥオドゥオ)"], "2025/04/17": ["TSMC", "(台湾・セミコンダクター)"], "2025/03/25": ["AZN", "(アストラゼネカ)"], "2025/02/20": ["MELI", "(メルカドリブレ)"]}'
+HANA_MEMO_FILE=backend/hana-memo-202509.txt

--- a/backend/.env
+++ b/backend/.env
@@ -1,1 +1,0 @@
-HANA_MEMO_FILE=backend/hana-memo-202509.txt


### PR DESCRIPTION
- `python-dotenv` を利用して、`.env` ファイルから環境変数を読み込むように変更
- `backend/data_fetcher.py` で、ハードコードされていたファイルパスを環境変数 `HANA_MEMO_FILE` から取得するように修正
- これにより、読み込むテキストファイルを変更する際に、コードを編集することなく `.env` ファイルを編集するだけで対応可能になります。