### PR TITLE
v0.1.2 fix: cronサービスが起動しない問題を修正

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -15,8 +15,8 @@ printenv | sed 's/^\(.*\)$/export \1/g' > "${ENV_FILE}"
 chmod +x "${ENV_FILE}"
 
 echo "Starting cron daemon..."
-# Start cron in the background
-cron
+# Start the cron service in the background
+service cron start
 
 echo "Starting Uvicorn web server..."
 # Start the uvicorn server in the foreground.


### PR DESCRIPTION
コンテナ起動スクリリプトstart.sh内でcronデーモンを起動する方法を修正しました。

旧来の`cron`コマンド呼び出しでは、デーモンがバックグラウンドで安定して動作しない場合がありました。これを`service cron start`に変更することで、cronがサービスとして確実に起動し、スケジュールされたジョブが実行されるようになります。