### PR TITLE
feat: Add AI commentary for indicators and earnings

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -525,6 +525,19 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             economicCard.innerHTML += '<p>本日予定されている重要経済指標はありません。</p>';
         }
+
+        // --- AI Commentary for Economic Indicators ---
+        if (indicators.economic_commentary) {
+            const commentaryDiv = document.createElement('div');
+            commentaryDiv.className = 'ai-commentary'; // Reuse existing style
+            commentaryDiv.innerHTML = `
+                <div class="ai-header">
+                    <h3>AI解説</h3>
+                </div>
+                <p>${indicators.economic_commentary.replace(/\n/g, '<br>')}</p>
+            `;
+            economicCard.appendChild(commentaryDiv);
+        }
         container.appendChild(economicCard);
 
         // --- Part 2: Earnings Announcements ---
@@ -585,6 +598,19 @@ document.addEventListener('DOMContentLoaded', () => {
             earningsCard.appendChild(earningsTable);
         } else {
             earningsCard.innerHTML += '<p>今日予定されている注目決算はありません。</p>';
+        }
+
+        // --- AI Commentary for Earnings ---
+        if (indicators.earnings_commentary) {
+            const commentaryDiv = document.createElement('div');
+            commentaryDiv.className = 'ai-commentary'; // Reuse existing style
+            commentaryDiv.innerHTML = `
+                <div class="ai-header">
+                    <h3>AI解説</h3>
+                </div>
+                <p>${indicators.earnings_commentary.replace(/\n/g, '<br>')}</p>
+            `;
+            earningsCard.appendChild(commentaryDiv);
         }
         container.appendChild(earningsCard);
     }


### PR DESCRIPTION
This feature adds AI-generated commentary for economic indicators and corporate earnings announcements on the "Indicators" tab.

Backend (`data_fetcher.py`):
- A new function `generate_indicators_commentary` is added to create commentary.
- For economic indicators, it generates commentary for 3-star indicators and impactful 2-star indicators (based on keywords like inflation, employment, etc.).
- For earnings announcements, it generates commentary for all listed companies.
- Handles cases where no commentary is needed by outputting "なし".

Frontend (`app.js`):
- The `renderIndicators` function is updated to display the new AI commentary sections directly below the respective tables.
- The new sections are styled using the existing `ai-commentary` class for consistency.