### PR TITLE
Fix(data_fetcher): Ensure AI column generation handles JSON response

### DIFF
--- a/backend/data_fetcher.py
+++ b/backend/data_fetcher.py
@@ -1077,18 +1077,30 @@ class MarketDataFetcher:
 ## 市場の構図（参考データ）
 {market_structure_str}
 """
-        prompt = base_prompt_intro + specific_instructions + data_section
+        json_format_instruction = """
+
+# 出力形式
+必ず以下のJSON形式で出力してください：
+{{
+    "response": "ここに指示に従って生成した解説全文を記述"
+}}
+
+重要：出力は有効なJSONである必要があります。"""
+        prompt = base_prompt_intro + specific_instructions + data_section + json_format_instruction
 
         try:
             messages = [
-                {"role": "system", "content": "あなたはプロの金融アナリストです。"},
+                {"role": "system", "content": "You are a helpful assistant designed to output JSON. Your response must be valid JSON."},
                 {"role": "user", "content": prompt}
             ]
-            generated_text = self._call_openai_api(
+            response_json = self._call_openai_api(
                 messages=messages,
                 max_tokens=1000,
-                temperature=0.6
+                temperature=0.6,
+                response_format={"type": "json_object"}
             )
+
+            generated_text = response_json.get('response', 'AIコラムの生成に失敗しました。')
 
             # レポートタイプのキーを決定
             report_type = "weekly_report" if today.weekday() == 0 else "daily_report"


### PR DESCRIPTION
The AI column generation was failing with a `JSONDecodeError`. This was because the `_call_openai_api` function expects a JSON response from the OpenAI API, but the prompt for the `generate_column` function did not instruct the model to return JSON, nor did the API call enforce a JSON response format.

This change aligns the `generate_column` function with other AI-powered functions in the script:
- Updates the system message to prime the model for JSON output.
- Modifies the user prompt to include an explicit instruction to return the content within a JSON object.
- Adds `response_format={'type': 'json_object'}` to the API call to enforce a valid JSON response.
- Parses the resulting JSON to extract the generated text content.

This resolves the error by ensuring a consistent and predictable response format from the API.