### PR TITLE
fix(frontend): Correctly initialize notification manager

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -49,6 +49,10 @@ document.addEventListener('DOMContentLoaded', () => {
             fetchDataAndRender();
             initSwipeNavigation();
             dashboardContainer.dataset.initialized = 'true';
+
+            // Initialize notifications after dashboard is shown
+            const notificationManager = new NotificationManager();
+            notificationManager.init();
         }
     }
 
@@ -1102,21 +1106,3 @@ style.textContent = `
 `;
 document.head.appendChild(style);
 
-// Initialize notification manager when dashboard is shown
-document.addEventListener('DOMContentLoaded', () => {
-    // Find the existing showDashboard function and modify it
-    const originalShowDashboard = window.showDashboard || function() {};
-
-    window.showDashboard = function() {
-        // Call original functionality
-        originalShowDashboard.apply(this, arguments);
-
-        const dashboardContainer = document.querySelector('.container');
-        if (dashboardContainer && !dashboardContainer.dataset.notificationsInitialized) {
-            // Initialize notifications
-            const notificationManager = new NotificationManager();
-            notificationManager.init();
-            dashboardContainer.dataset.notificationsInitialized = 'true';
-        }
-    };
-});


### PR DESCRIPTION
The notification permission prompt was not appearing because the NotificationManager was never initialized.

This was due to a flawed attempt to wrap the `showDashboard` function. The wrapping logic failed because `showDashboard` is not a global function.

This commit moves the `NotificationManager` initialization directly into the `showDashboard` function, ensuring it is called after successful authentication when the dashboard becomes visible. It also removes the old, non-functional code that attempted the wrapping.