### PR TITLE
Fix: Reset scroll position on tab change

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -171,6 +171,9 @@ document.addEventListener('DOMContentLoaded', () => {
             document.querySelectorAll('.tab-pane').forEach(pane => {
                 pane.classList.toggle('active', pane.id === `${targetTab}-content`);
             });
+
+            // Scroll to the top of the page
+            window.scrollTo(0, 0);
         });
     }
 


### PR DESCRIPTION
When swiping between tabs, the scroll position was maintained from the previous tab. This change ensures that the view is scrolled to the top every time a new tab is selected, either by clicking or swiping.

This is achieved by adding `window.scrollTo(0, 0);` to the `initTabs` function in `frontend/app.js`.