### PR TITLE
Fix: Ensure page scrolls to top on tab change

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -165,15 +165,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const targetTab = e.target.dataset.tab;
 
-            // Scroll to the top of the page before switching the tab
-            window.scrollTo(0, 0);
-
             document.querySelectorAll('.tab-button').forEach(button => {
                 button.classList.toggle('active', button.dataset.tab === targetTab);
             });
             document.querySelectorAll('.tab-pane').forEach(pane => {
                 pane.classList.toggle('active', pane.id === `${targetTab}-content`);
             });
+
+            // Scroll to the top of the page after a short delay.
+            // This ensures the browser has processed the tab change before scrolling,
+            // which is more reliable, especially after swipe gestures.
+            setTimeout(() => {
+                window.scrollTo(0, 0);
+            }, 0);
         });
     }
 


### PR DESCRIPTION
This commit addresses an issue where switching tabs, either by tapping or swiping, did not reliably scroll the new tab's content to the top of the page. This was likely due to a race condition where the scroll command was executed before the browser had finished rendering the new tab content.

The fix wraps the `window.scrollTo(0, 0)` call inside a `setTimeout` with a 0ms delay. This defers the scroll execution until the next event loop, giving the browser sufficient time to process the tab change and ensuring the scroll command is applied correctly. This provides a reliable "snap to top" effect as requested by the user.

This change applies to both tap and swipe gestures.