### PR TITLE
Fix PWA re-authentication and notification refresh issues

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -119,7 +119,7 @@ def verify_pin(pin_data: PinVerification, response: Response):
             max_age=expires.total_seconds(),
             samesite="lax",
             path="/",
-            secure=False  # Set to True in production with HTTPS
+            secure=True  # Set to True for PWA compatibility
         )
         return {"message": "Authentication successful"}
     else:

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -133,9 +133,29 @@ self.addEventListener('notificationclick', event => {
   event.notification.close();
 
   if (event.action === 'view' || !event.action) {
-    event.waitUntil(
-      clients.openWindow('/')
-    );
+    const promiseChain = syncData().then(() => {
+      return clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true
+      }).then(windowClients => {
+        let matchingClient = null;
+        for (let i = 0; i < windowClients.length; i++) {
+          const client = windowClients[i];
+          if (client.url.endsWith('/')) {
+            matchingClient = client;
+            break;
+          }
+        }
+
+        if (matchingClient) {
+          return matchingClient.focus();
+        } else {
+          return clients.openWindow('/');
+        }
+      });
+    });
+
+    event.waitUntil(promiseChain);
   }
 });
 


### PR DESCRIPTION
This commit addresses two problems with the PWA's behavior on mobile devices:

1.  **Fix re-authentication on app launch:** The session cookie was being set with `secure=False`, which caused it to be discarded when the PWA was closed and reopened on iOS. By setting `secure=True` in `backend/main.py`, the cookie is now correctly persisted, maintaining the user's session for 30 days as intended.

2.  **Fix app content not updating on notification click:** The service worker's `notificationclick` handler was only opening a new window. It has been enhanced to first trigger a data refresh by calling `syncData()`. It then focuses the existing app window if it's open, or opens a new one. This ensures that interacting with a notification immediately shows the latest content.