### PR TITLE
Increase swipe threshold for tab navigation

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -841,7 +841,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const tabContainer = document.querySelector('.tab-container');
         let touchstartX = 0;
         let touchendX = 0;
-        const swipeThreshold = 50; // Minimum horizontal distance for a swipe
+        const swipeThreshold = 100; // Minimum horizontal distance for a swipe
 
         contentArea.addEventListener('touchstart', e => {
             touchstartX = e.changedTouches[0].screenX;


### PR DESCRIPTION
The swipe sensitivity for tab navigation was too high, causing unintended tab changes with small flicks. This change increases the `swipeThreshold` from 50 to 100 in `frontend/app.js` to require a longer swipe to switch tabs.