### PR TITLE
fix(server): Remove --reload flag from uvicorn startup

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -59,4 +59,4 @@ tail -f /var/log/cron.log /app/logs/cron_error.log 2>/dev/null &
 
 echo "Starting Uvicorn web server..."
 # Start the uvicorn server in the foreground.
-exec uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
+exec uvicorn backend.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
The uvicorn server was being started with the `--reload` flag, which is intended for development purposes. This flag causes the server to automatically restart when file changes are detected.

In this application, log files and push subscription data are written to directories that are monitored by the reloader. This caused the server to restart unintentionally, clearing in-memory state, including JWT signing keys if they were not persisted correctly. This led to users being logged out prematurely.

By removing the `--reload` flag, the server will run in a stable, production-like mode, ensuring session persistence and preventing unexpected logouts.