### PR TITLE
fix: Improve auth flow stability on initial load

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -139,16 +139,26 @@ document.addEventListener('DOMContentLoaded', () => {
         if (authContainer) authContainer.style.display = 'none';
         if (dashboardContainer) dashboardContainer.style.display = 'block';
 
-        if (!dashboardContainer.dataset.initialized) {
-            console.log("HanaView Dashboard Initialized");
-            initTabs();
-            fetchDataAndRender();
-            initSwipeNavigation();
-            dashboardContainer.dataset.initialized = 'true';
+        const isInitialized = dashboardContainer.dataset.initialized === 'true';
 
+        // Always fetch data to ensure it's fresh, especially if a previous attempt was interrupted.
+        fetchDataAndRender();
+
+        if (isInitialized) {
+            return; // Don't re-initialize tabs, swipes, or notifications
+        }
+
+        // First-time initialization
+        console.log("HanaView Dashboard Initialized");
+        initTabs();
+        initSwipeNavigation();
+        dashboardContainer.dataset.initialized = 'true';
+
+        // Delay notification init to prevent UI blocking from the permission prompt
+        setTimeout(() => {
             const notificationManager = new NotificationManager();
             notificationManager.init();
-        }
+        }, 500); // Increased delay for robustness
     }
 
     function showAuthScreen() {


### PR DESCRIPTION
This commit addresses a race condition that occurred on initial login, particularly on PWA. The notification permission prompt could block the UI thread before the dashboard was fully rendered, causing the app to appear frozen or stuck on a loading screen.

The `showDashboard` function in `app.js` has been refactored to:
1.  Always trigger `fetchDataAndRender` to ensure data is loaded, even if a previous attempt was interrupted.
2.  Delay the initialization of the `NotificationManager` with a more robust timeout (500ms). This ensures the dashboard has time to render before the permission prompt appears.
3.  Ensure that one-time initializations (tabs, swipe gestures) are only run once.