### PR TITLE
PWA通知機能とバックグラウンド認証を修正

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,6 +32,11 @@
         <header class="header">
             <h1>朝の<span style="color: #FF00A5;">５分</span>市況チェック</h1>
             <p class="last-updated" id="last-updated">Last updated: --</p>
+        <!-- 通知設定ボタンを追加 -->
+        <button id="notification-setup-btn" class="notification-btn" style="display: none;">
+            🔔 通知を有効にする
+        </button>
+        <span id="notification-status" class="notification-status"></span>
         </header>
 
         <div class="tab-container">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -730,3 +730,43 @@ body {
         font-size: 1.5em;
     }
 }
+
+.notification-btn {
+    background-color: var(--tab-active-bg);
+    color: white;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 5px;
+    cursor: pointer;
+    margin: 10px 0;
+    font-size: 14px;
+}
+
+.notification-btn:hover {
+    opacity: 0.9;
+}
+
+.notification-status {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-left: 10px;
+}
+
+@keyframes slideIn {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    } to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+@keyframes slideOut {
+    from {
+        transform: translateX(0);
+        opacity: 1;
+    } to {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -11,46 +11,56 @@ const APP_SHELL_URLS = [
   'https://d3js.org/d3.v7.min.js'
 ];
 const DATA_URL = '/api/data';
-const DB_NAME = 'HanaViewDB';
-const DB_VERSION = 1;
-const TOKEN_STORE_NAME = 'auth-tokens';
+const TOKEN_STORE = 'auth-tokens';
+let cachedToken = null;
 
-// --- IndexedDB Helper ---
-function openDB() {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION);
-    request.onerror = () => reject("Error opening DB");
-    request.onsuccess = () => resolve(request.result);
-    request.onupgradeneeded = event => {
-      const db = event.target.result;
-      if (!db.objectStoreNames.contains(TOKEN_STORE_NAME)) {
-        db.createObjectStore(TOKEN_STORE_NAME, { keyPath: 'id' });
-      }
-    };
-  });
+// メッセージリスナーでトークンを受け取る
+self.addEventListener('message', async (event) => {
+    if (event.data.type === 'SET_TOKEN') {
+        cachedToken = event.data.token;
+        console.log('[SW] Token cached');
+
+        // IndexedDBに保存（永続化）
+        await saveTokenToIndexedDB(event.data.token);
+    }
+});
+
+// IndexedDBヘルパー関数
+async function saveTokenToIndexedDB(token) {
+    const db = await openDB();
+    const tx = db.transaction([TOKEN_STORE], 'readwrite');
+    const store = tx.objectStore(TOKEN_STORE);
+    await store.put({ id: 'main', token: token, timestamp: Date.now() });
+    console.log('[SW] Token saved to IndexedDB');
 }
 
-async function getTokenFromDB() {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction([TOKEN_STORE_NAME], 'readonly');
-    const store = transaction.objectStore(TOKEN_STORE_NAME);
-    const request = store.get('auth_token');
-    request.onerror = () => reject("Error fetching token");
-    request.onsuccess = () => {
-      resolve(request.result ? request.result.value : null);
-    };
-  });
+async function getTokenFromIndexedDB() {
+    try {
+        const db = await openDB();
+        const tx = db.transaction([TOKEN_STORE], 'readonly');
+        const store = tx.objectStore(TOKEN_STORE);
+        const data = await store.get('main');
+        return data ? data.token : null;
+    } catch (error) {
+        console.error('[SW] Failed to get token from IndexedDB:', error);
+        return null;
+    }
 }
 
-// --- Authenticated Fetch for Service Worker ---
-async function fetchWithAuthFromSW(url, options = {}) {
-  const token = await getTokenFromDB();
-  const headers = new Headers(options.headers || {});
-  if (token) {
-    headers.append('Authorization', `Bearer ${token}`);
-  }
-  return fetch(url, { ...options, headers });
+async function openDB() {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open('HanaViewDB', 1);
+
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => resolve(request.result);
+
+        request.onupgradeneeded = (event) => {
+            const db = event.target.result;
+            if (!db.objectStoreNames.contains(TOKEN_STORE)) {
+                db.createObjectStore(TOKEN_STORE, { keyPath: 'id' });
+            }
+        };
+    });
 }
 
 
@@ -84,36 +94,46 @@ self.addEventListener('activate', event => {
   self.clients.claim();
 });
 
-// Fetch event (Stale-while-revalidate for data)
-self.addEventListener('fetch', event => {
-  const { request } = event;
+// Fetch イベントの修正
+self.addEventListener('fetch', async (event) => {
+    const { request } = event;
 
-  // For data API, use stale-while-revalidate.
-  // The request from the app already has auth headers.
-  if (request.url.includes(DATA_URL)) {
+    // APIリクエストの場合、認証ヘッダーを追加
+    if (request.url.includes('/api/') &&
+        !request.url.includes('/api/auth/') &&
+        !request.url.includes('/api/vapid-public-key')) {
+
+        event.respondWith(
+            (async () => {
+                // トークンを取得（キャッシュ優先）
+                let token = cachedToken;
+                if (!token) {
+                    token = await getTokenFromIndexedDB();
+                    cachedToken = token;  // キャッシュ
+                }
+
+                if (token) {
+                    const modifiedRequest = new Request(request, {
+                        headers: new Headers({
+                            ...Object.fromEntries(request.headers.entries()),
+                            'Authorization': `Bearer ${token}`
+                        })
+                    });
+                    return fetch(modifiedRequest);
+                }
+
+                return fetch(request);
+            })()
+        );
+        return;
+    }
+
+    // 既存のキャッシュ処理
     event.respondWith(
-      caches.open(CACHE_NAME).then(cache => {
-        const networkResponsePromise = fetch(request).then(networkResponse => {
-          if (networkResponse.ok) {
-            cache.put(request, networkResponse.clone());
-          }
-          return networkResponse;
-        });
-
-        return cache.match(request).then(cachedResponse => {
-          return cachedResponse || networkResponsePromise;
-        });
-      })
+        caches.match(request).then(cachedResponse => {
+            return cachedResponse || fetch(request);
+        })
     );
-    return;
-  }
-
-  // For app shell, use cache-first.
-  event.respondWith(
-    caches.match(request).then(cachedResponse => {
-      return cachedResponse || fetch(request);
-    })
-  );
 });
 
 // Push notification handler
@@ -164,8 +184,8 @@ self.addEventListener('sync', event => {
 async function syncData() {
   try {
     console.log('Service Worker: Syncing data...');
-    // Use the authenticated fetch function
-    const response = await fetchWithAuthFromSW(DATA_URL);
+    // The new fetch handler will add auth headers automatically
+    const response = await fetch(DATA_URL);
     if (response.ok) {
       const data = await response.json();
       const cache = await caches.open(CACHE_NAME);


### PR DESCRIPTION
このコミットは、特にiOS PWAにおいてプッシュ通知が正しく機能しなかった複数の問題を解決するための包括的なソリューションを実装します。

主な変更点:
- UIに手動の「通知を有効にする」ボタンを追加。これにより、iOS PWAの要件であるユーザーインタラクションによって通知許可プロンプトをトリガーできるようになり、起動時にNotification APIが利用できないタイミングの問題が解決されます。
- `app.js`のNotificationManagerを完全にリファクタリングし、許可のライフサイクルを管理し、必要に応じてボタンを表示し、購読を処理するようにしました。
- Service Worker (`sw.js`) は、メインスレッドから`postMessage`を介してJWTを受け取り、`localStorage`がワーカーコンテキストでアクセスできないため、永続化のためにIndexedDBに保存するようになりました。
- Service Workerの`fetch`ハンドラを更新し、API呼び出しをインターセプトしてIndexedDBから認証トークンを添付するようにしました。これにより、バックグラウンド同期とプッシュ通知によってトリガーされるフェッチが適切に認証されるようになります。
- 定期的なバックグラウンド同期機能は維持されています。