### PR TITLE
feat: スワイプ判定に角度の考慮を追加

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -443,17 +443,25 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Swipe Navigation ---
     function initSwipeNavigation() {
         const contentArea = document.getElementById('dashboard-content');
-        let touchstartX = 0, touchendX = 0;
-        contentArea.addEventListener('touchstart', e => { touchstartX = e.changedTouches[0].screenX; }, { passive: true });
+        let touchstartX = 0, touchendX = 0, touchstartY = 0, touchendY = 0;
+        contentArea.addEventListener('touchstart', e => {
+            touchstartX = e.changedTouches[0].screenX;
+            touchstartY = e.changedTouches[0].screenY;
+        }, { passive: true });
         contentArea.addEventListener('touchend', e => {
             touchendX = e.changedTouches[0].screenX;
-            if (Math.abs(touchendX - touchstartX) < 100) return;
-            const tabButtons = Array.from(document.querySelectorAll('.tab-button'));
-            const currentIndex = tabButtons.findIndex(b => b.classList.contains('active'));
-            let nextIndex = (touchendX > touchstartX) ? currentIndex - 1 : currentIndex + 1;
-            if (nextIndex < 0) nextIndex = tabButtons.length - 1;
-            else if (nextIndex >= tabButtons.length) nextIndex = 0;
-            tabButtons[nextIndex]?.click();
+            touchendY = e.changedTouches[0].screenY;
+            const deltaX = Math.abs(touchendX - touchstartX);
+            const deltaY = Math.abs(touchendY - touchstartY);
+
+            if (deltaX > 100 && deltaX > deltaY * 1.5) {
+                const tabButtons = Array.from(document.querySelectorAll('.tab-button'));
+                const currentIndex = tabButtons.findIndex(b => b.classList.contains('active'));
+                let nextIndex = (touchendX > touchstartX) ? currentIndex - 1 : currentIndex + 1;
+                if (nextIndex < 0) nextIndex = tabButtons.length - 1;
+                else if (nextIndex >= tabButtons.length) nextIndex = 0;
+                tabButtons[nextIndex]?.click();
+            }
         });
     }
 


### PR DESCRIPTION
上下スワイプ時の誤操作を防ぐため、スワイプの判定ロジックを修正しました。

- `touchstart`および`touchend`イベントでY座標も取得するように変更。
- 水平方向と垂直方向の移動量を比較し、水平方向の移動が顕著な場合にのみ横スワイプとして認識するように条件を更新。
- これにより、斜め方向のスワイプが意図せず横スワイプとして扱われる問題が解消されます。